### PR TITLE
ensure prisma client generated before next build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "start-docker": "npm-run-all check-db update-tracker set-routes-manifest start-server",
     "start-env": "node scripts/start-env.js",
     "start-server": "node server.js",
+    "prebuild-app": "npm-run-all copy-db-files build-db-client",
     "build-app": "next build",
     "build-components": "rollup -c rollup.components.config.mjs",
     "build-tracker": "rollup -c rollup.tracker.config.mjs",


### PR DESCRIPTION
## Summary
- run `copy-db-files` and `prisma generate` automatically before `next build`

## Testing
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db pnpm run build-app`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2cb966de083249e0be39f47fcbee2