### PR TITLE
Generate Prisma client before Next.js build

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start-docker": "npm-run-all check-db update-tracker set-routes-manifest start-server",
     "start-env": "node scripts/start-env.js",
     "start-server": "node server.js",
-    "build-app": "next build",
+    "build-app": "cross-env DATABASE_TYPE=postgresql pnpm run build-db && next build",
     "build-components": "rollup -c rollup.components.config.mjs",
     "build-tracker": "rollup -c rollup.tracker.config.mjs",
     "build-db": "npm-run-all copy-db-files build-db-client",


### PR DESCRIPTION
## Summary
- ensure Netlify build runs Prisma client generation by invoking build-db prior to `next build`

## Testing
- `pnpm run build-app`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2cb966de083249e0be39f47fcbee2