### PR TITLE
fix: handle empty JSON responses

### DIFF
--- a/src/lib/fetch.test.ts
+++ b/src/lib/fetch.test.ts
@@ -1,0 +1,15 @@
+import { request } from './fetch';
+
+describe('request', () => {
+  it('handles empty response body', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    (global as any).fetch = mockFetch;
+
+    await expect(request('GET', '/test')).resolves.toEqual({
+      ok: true,
+      status: 204,
+      data: undefined,
+      error: undefined,
+    });
+  });
+});

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -23,7 +23,17 @@ export async function request(
     },
     body,
   }).then(async res => {
-    const data = await res.json();
+    let data: any = undefined;
+
+    const text = await res.text();
+
+    if (text && text.length > 0) {
+      try {
+        data = JSON.parse(text);
+      } catch {
+        data = text;
+      }
+    }
 
     return {
       ok: res.ok,


### PR DESCRIPTION
## Summary
- avoid JSON parsing errors on empty or non-JSON responses in fetch utility
- add unit test for empty response handling

## Testing
- `npm test`
- `npm run lint` *(fails: 'IntersectionObserverCallback' is not defined, unable to resolve '@jest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68a2d59547a48324bc05709507c979e3