### PR TITLE
Handle empty JSON responses

### DIFF
--- a/src/lib/__tests__/fetch.test.ts
+++ b/src/lib/__tests__/fetch.test.ts
@@ -1,0 +1,20 @@
+/* eslint-disable import/no-unresolved */
+import { expect } from '@jest/globals';
+import { request } from '../fetch';
+
+test('request handles empty JSON response', async () => {
+  const originalFetch = global.fetch;
+  // Mock fetch to return an empty body which would normally cause res.json() to throw
+  global.fetch = jest.fn(() => Promise.resolve(new Response(null, { status: 204 }))) as any;
+
+  const result = await request('GET', '/test');
+
+  expect(result).toEqual({
+    ok: true,
+    status: 204,
+    data: null,
+    error: undefined,
+  });
+
+  global.fetch = originalFetch;
+});

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -23,7 +23,12 @@ export async function request(
     },
     body,
   }).then(async res => {
-    const data = await res.json();
+    let data;
+    try {
+      data = await res.json();
+    } catch {
+      data = null;
+    }
 
     return {
       ok: res.ok,


### PR DESCRIPTION
## Summary
- avoid JSON parsing errors on empty responses in shared fetch helper
- add regression test for empty-body handling

## Testing
- `npm test`
- `npm run lint` *(fails: 'IntersectionObserverCallback' is not defined, unable to resolve '@jest/globals')*


------
https://chatgpt.com/codex/tasks/task_e_68a2d59547a48324bc05709507c979e3