### PR TITLE
Handle empty responses in fetch utility

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -23,7 +23,16 @@ export async function request(
     },
     body,
   }).then(async res => {
-    const data = await res.json();
+    const text = await res.text();
+    let data: any;
+
+    if (text) {
+      try {
+        data = JSON.parse(text);
+      } catch (e) {
+        data = text;
+      }
+    }
 
     return {
       ok: res.ok,


### PR DESCRIPTION
## Summary
- avoid parsing JSON from empty or non-JSON responses

## Testing
- `npm test`
- `npm run lint` *(fails: 'IntersectionObserverCallback' is not defined, @jest/globals unresolved)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d59547a48324bc05709507c979e3